### PR TITLE
Add site structure with service offering pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,28 +1,35 @@
 lang: en
-timezone: America/New_York
+timezone: Europe/Amsterdam
 future: true
 
-title: Creative Coding & Technology
-tagline: Exploring the intersection of music, machine learning, and live coding
+title: Creative Coding Tech
+tagline: Code as contemplation. Technology as transformation.
 
 # Site logo
 avatar: /logo.png
 description: >-
-  A blog about creative coding, live music with Sonic Pi, machine learning applications in audio,
-  and the intersectionality of technology and musical expression.
+  Code as contemplation. Vision quest facilitation, lucid dream training,
+  shadow work, and creative coding as ritual practice.
 
 url: "https://creativecodingtech.com"
 
 github:
   username: wingie
 
+twitter:
+  username: creativecodingtech
+
 social:
   name: Wingston Sharon Wilson
   email: example@domain.com
   links:
     - https://github.com/wingie
+    - https://linkedin.com/in/wingstonwilson
 
 author: Wingston Sharon Wilson
+
+# Google Search Console verification (replace with actual code)
+# google_site_verification: "your-verification-code"
 
 theme: jekyll-theme-chirpy
 

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -1,0 +1,9 @@
+---
+layout: default
+---
+
+{% include lang.html %}
+
+<div class="landing-page px-1">
+  {{ content }}
+</div>

--- a/_layouts/offering.html
+++ b/_layouts/offering.html
@@ -1,0 +1,41 @@
+---
+layout: default
+refactor: true
+---
+
+{% include lang.html %}
+
+<article class="px-1 offering-page">
+  {% if page.title %}
+    <h1 class="dynamic-title">{{ page.title }}</h1>
+  {% endif %}
+
+  <div class="content offering-content">
+    {{ content }}
+  </div>
+
+  {% if page.schema %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "name": "{{ page.title }}",
+    "provider": {
+      "@type": "Person",
+      "name": "Wingston Sharon Wilson",
+      "url": "https://creativecodingtech.com/about/"
+    },
+    "areaServed": {
+      "@type": "Place",
+      "name": "{{ page.schema.area | default: 'Europe' }}"
+    },
+    "description": "{{ page.description }}",
+    "offers": {
+      "@type": "Offer",
+      "price": "{{ page.schema.price | default: '0' }}",
+      "priceCurrency": "{{ page.schema.currency | default: 'EUR' }}"
+    }
+  }
+  </script>
+  {% endif %}
+</article>

--- a/_sass/pages/_index.scss
+++ b/_sass/pages/_index.scss
@@ -5,3 +5,5 @@
 @forward 'tags';
 @forward 'archives';
 @forward 'category-tag';
+@forward 'landing';
+@forward 'offerings';

--- a/_sass/pages/_landing.scss
+++ b/_sass/pages/_landing.scss
@@ -1,0 +1,81 @@
+/* Landing Page Styles */
+
+.landing-page {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.landing {
+  max-width: 700px;
+  text-align: center;
+  padding: 2rem 1rem;
+
+  .landing-headline {
+    font-size: 2rem;
+    font-weight: 400;
+    line-height: 1.4;
+    margin-bottom: 2rem;
+    color: var(--heading-color);
+
+    @media (min-width: 768px) {
+      font-size: 2.5rem;
+    }
+  }
+
+  .lead {
+    font-size: 1.15rem;
+    line-height: 1.7;
+    color: var(--text-color);
+    margin-bottom: 1.5rem;
+  }
+
+  .tagline {
+    font-size: 1rem;
+    color: var(--text-muted-color);
+    margin-bottom: 3rem;
+  }
+
+  .offerings-nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-bottom: 3rem;
+
+    .offering-link {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      border: 1px solid var(--border-color);
+      border-radius: 4px;
+      color: var(--text-color);
+      text-decoration: none;
+      font-size: 0.9rem;
+      transition: all 0.2s ease;
+
+      &:hover {
+        border-color: var(--link-color);
+        color: var(--link-color);
+        text-decoration: none;
+      }
+    }
+  }
+
+  .cta-button {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background-color: var(--link-color);
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 1rem;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: var(--link-hover-color);
+      text-decoration: none;
+      color: white;
+    }
+  }
+}

--- a/_sass/pages/_offerings.scss
+++ b/_sass/pages/_offerings.scss
@@ -1,0 +1,114 @@
+/* Offering Page Styles */
+
+.offering-page {
+  .offering-content {
+    max-width: 750px;
+
+    h2 {
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      font-size: 1.5rem;
+      font-weight: 500;
+    }
+
+    h3 {
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+
+    p {
+      line-height: 1.8;
+      margin-bottom: 1.25rem;
+    }
+
+    ul, ol {
+      margin-bottom: 1.25rem;
+      padding-left: 1.5rem;
+
+      li {
+        margin-bottom: 0.5rem;
+        line-height: 1.7;
+      }
+    }
+
+    strong {
+      font-weight: 600;
+    }
+
+    em {
+      font-style: italic;
+    }
+
+    a {
+      color: var(--link-color);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+/* Oracle Form Styles */
+.oracle-form {
+  max-width: 600px;
+  margin: 2rem 0;
+
+  .form-group {
+    margin-bottom: 1.5rem;
+
+    label {
+      display: block;
+      margin-bottom: 0.5rem;
+      font-weight: 500;
+      color: var(--heading-color);
+    }
+
+    input[type="text"],
+    input[type="email"],
+    textarea,
+    select {
+      width: 100%;
+      padding: 0.75rem;
+      border: 1px solid var(--border-color);
+      border-radius: 4px;
+      background-color: var(--main-bg);
+      color: var(--text-color);
+      font-size: 1rem;
+      font-family: inherit;
+
+      &:focus {
+        outline: none;
+        border-color: var(--link-color);
+      }
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 100px;
+    }
+
+    select {
+      cursor: pointer;
+    }
+  }
+
+  .submit-button {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background-color: var(--link-color);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: var(--link-hover-color);
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,30 @@
 ---
-layout: home
-# Index page
+layout: landing
+title: Creative Coding Tech
 ---
+
+<div class="landing">
+  <h1 class="landing-headline">Code as contemplation.<br>Technology as transformation.</h1>
+
+  <p class="lead">
+    I guide people through thresholds—vision quests in wilderness,
+    lucid dreams at night, shadow work in session,
+    and creative coding as ritual practice.
+  </p>
+
+  <p class="tagline">
+    Engineering leader turned consciousness guide.
+    The combination matters.
+  </p>
+
+  <nav class="offerings-nav">
+    <a href="/offerings/vision-quest-facilitation/" class="offering-link">Vision Quest</a>
+    <a href="/offerings/lucid-dream-training/" class="offering-link">Lucid Dreaming</a>
+    <a href="/offerings/spirit-guide-connection/" class="offering-link">Spirit Guide Work</a>
+    <a href="/offerings/shadow-work-integration/" class="offering-link">Shadow Work</a>
+    <a href="/offerings/insight-meditation/" class="offering-link">Insight Meditation</a>
+    <a href="/offerings/creative-coding-ritual/" class="offering-link">Creative Coding</a>
+  </nav>
+
+  <a href="/oracle/" class="cta-button">Ask the Oracle</a>
+</div>

--- a/offerings/creative-coding-ritual/index.md
+++ b/offerings/creative-coding-ritual/index.md
@@ -1,0 +1,68 @@
+---
+layout: offering
+title: Creative Coding as Contemplative Practice
+description: Code as meditation. Algorithms as ritual. A different approach to creative technology.
+keywords: creative coding, generative art, touchdesigner workshop, creative technology, live coding
+permalink: /offerings/creative-coding-ritual/
+schema:
+  area: Amsterdam
+  price: 150
+  currency: EUR
+---
+
+Most creative coding education focuses on output—make cool visuals, build interactive installations, learn the tools. This is valuable, but incomplete.
+
+What if code itself could be a contemplative practice? What if the act of programming could be as meditative as sitting?
+
+## The Approach
+
+We treat creative coding as a vehicle for:
+
+- **Attention training** — The focus required to debug is the same focus cultivated in meditation
+- **Surrender** — Generative systems teach us to release control and collaborate with emergence
+- **Ritual creation** — Building personal tools for transformation, not just entertainment
+- **Embodied technology** — Gesture control, biofeedback, body-as-interface
+
+## What We Work With
+
+- **TouchDesigner** — Real-time visual systems
+- **Sonic Pi / SuperCollider** — Live coded music
+- **Wekinator + gesture control** — Body-responsive systems
+- **Custom ritual tools** — Whatever serves your practice
+
+## Format
+
+**Introduction Workshop:** €150 (half-day)
+
+- No coding experience required
+- Build your first generative system
+- Explore code as contemplative practice
+- Online or in-person (Amsterdam)
+
+**8-Week Course:** €600
+
+- Weekly sessions building skills progressively
+- Focus on creating a personal ritual tool
+- Small cohort (max 8)
+
+**Private Mentorship:** €750/session
+
+- Custom curriculum
+- For artists, practitioners, technologists
+- Project-based or exploratory
+
+**Intensive Weekend:** €800
+
+- Full immersion
+- Build a complete project
+- Integration of practice and technology
+
+## Why This Matters
+
+Technology shapes consciousness. The tools we use, the systems we build, the interfaces we inhabit—all of these condition how we perceive and interact with reality.
+
+Most technology is designed for extraction—attention, data, money. But it doesn't have to be. We can build technologies that support awareness, that facilitate connection, that serve transformation.
+
+This is what I mean by creative coding as ritual: building tools that change us for the better.
+
+[Explore →](/oracle/)

--- a/offerings/insight-meditation/index.md
+++ b/offerings/insight-meditation/index.md
@@ -1,0 +1,60 @@
+---
+layout: offering
+title: Insight Meditation
+description: Traditional vipassana practice for seeing clearly. Individual instruction and small group sits in Amsterdam.
+keywords: insight meditation, vipassana, mindfulness amsterdam, meditation teacher netherlands
+permalink: /offerings/insight-meditation/
+schema:
+  area: Amsterdam
+  price: 100
+  currency: EUR
+---
+
+Insight meditation (vipassana) is the practice of seeing clearly—observing the arising and passing of all phenomena without grasping or aversion. It's simple, but not easy. And it transforms everything.
+
+## What I Offer
+
+**Weekly Sits (Amsterdam)**
+
+- Thursday evenings, 7-9pm
+- Guided meditation + dharma talk
+- All levels welcome
+- Dana (donation) based
+
+**Individual Instruction**
+
+- Personalized practice guidance
+- Working with specific hindrances
+- Deepening concentration
+- Navigating difficult territory
+
+**Retreat Support**
+
+- Preparation for intensive retreats
+- Integration after retreats
+- Practice between retreats
+
+## The Practice
+
+Insight meditation strips away technique to reveal what's always already here:
+
+- **Attention to breathing** as anchor
+- **Noting** to sharpen awareness
+- **Body scanning** to include the whole field
+- **Choiceless awareness** as practice matures
+
+The goal is not to feel good (though you might). The goal is to see clearly how experience actually works—its impermanence, its unsatisfactoriness when grasped, its lack of fixed self.
+
+## Background
+
+I've practiced insight meditation for 15+ years, including multiple extended retreats in the Mahasi Sayadaw tradition. I'm not a monk or authorized teacher in any formal lineage—I'm a householder practitioner who has found this practice indispensable and wants to share it.
+
+## Rates
+
+**Weekly Sits:** Dana (suggested €10-20)
+
+**Individual Session:** €100 (60 minutes)
+
+**Monthly Mentorship:** €300 (4 sessions)
+
+[Connect →](/oracle/)

--- a/offerings/lucid-dream-training/index.md
+++ b/offerings/lucid-dream-training/index.md
@@ -1,0 +1,66 @@
+---
+layout: offering
+title: Lucid Dream Training
+description: Learn to wake up inside your dreams. A structured approach to lucid dreaming combining Western techniques with contemplative practice.
+keywords: lucid dreaming course, lucid dream training, learn lucid dreaming, dream yoga
+permalink: /offerings/lucid-dream-training/
+schema:
+  area: Online
+  price: 149
+  currency: EUR
+---
+
+In a lucid dream, you know you're dreaming while you're dreaming. This awareness transforms sleep from passive recovery into active exploration—a laboratory for facing fears, rehearsing challenges, and encountering aspects of psyche normally hidden from view.
+
+## What You'll Learn
+
+### Foundation (Weeks 1-4)
+
+- Dream recall techniques
+- Reality testing that actually works
+- Sleep architecture and optimal timing
+- The MILD, WILD, and WBTB methods
+
+### Intermediate (Weeks 5-8)
+
+- Stabilizing lucidity once achieved
+- Dream control vs. dream collaboration
+- Working with recurring dreams and nightmares
+- The hypnagogic state as gateway
+
+### Advanced (Ongoing)
+
+- Dream yoga perspectives
+- Meeting dream figures as autonomous aspects of psyche
+- The clear light of sleep
+- Lucid dreaming as preparation for death
+
+## Format Options
+
+**Self-Paced Course:** €149
+
+- 8 video modules
+- Guided audio practices
+- Dream journal templates
+- Lifetime access
+
+**8-Week Live Cohort:** €395
+
+- Weekly group calls
+- Direct feedback on your practice
+- Small group (max 12)
+- Runs 3x per year
+
+**Private Training:** €750/session
+
+- 1:1 guidance
+- Custom protocol based on your sleep patterns
+- Includes hypnotic inductions and audio recordings
+
+## The Technical Edge
+
+My approach differs from most lucid dreaming courses in one key way: I treat dreams as information systems.
+
+As an engineer, I'm interested in the *architecture* of dreaming—the consistent patterns, the signal-to-noise ratio, the debugging process when techniques don't work. This analytical lens, combined with contemplative practice, creates a framework that works for people who need to understand *why* something works, not just that it does.
+
+[Begin with the Oracle →](/oracle/)

--- a/offerings/shadow-work-integration/index.md
+++ b/offerings/shadow-work-integration/index.md
@@ -1,0 +1,70 @@
+---
+layout: offering
+title: Shadow Work Integration
+description: Reclaim the parts of yourself you've hidden, rejected, or forgotten. Facilitated shadow work for lasting transformation.
+keywords: shadow work, shadow integration, shadow work facilitator, jung shadow work
+permalink: /offerings/shadow-work-integration/
+schema:
+  area: Amsterdam
+  price: 200
+  currency: EUR
+---
+
+The shadow contains everything you've rejected, hidden, or simply never had permission to be. Your anger, your power, your sexuality, your creativity, your darkness—but also your light, your gifts, your unlived potential.
+
+Shadow work is the process of reclaiming these parts. Not fixing them. Reclaiming them.
+
+## How We Work
+
+**Individual Sessions** combine:
+
+- Dialogue with shadow figures
+- Somatic awareness and body-based techniques
+- Active imagination and visualization
+- Integration practices for daily life
+
+### The Arc of a Session
+
+1. Identify what's constellated (the pattern showing up in your life)
+2. Locate it in the body
+3. Give it voice/form/image
+4. Dialogue and negotiation
+5. Integration ritual
+6. Homework for embodiment
+
+## Common Shadow Territory
+
+- The achiever who can't rest
+- The helper who can't receive
+- The peaceful one who can't access anger
+- The successful one who feels like a fraud
+- The spiritual seeker avoiding human messiness
+- The rational mind terrified of the irrational
+
+## Format
+
+**Single Session:** €200 (90 minutes)
+
+- Focused work on one specific pattern
+- Good for exploring if this approach fits
+
+**3-Session Series:** €500
+
+- Deeper work on an interconnected theme
+- Homework between sessions
+- Common starting point
+
+**Ongoing Work:** €750/month
+
+- 2 sessions per month
+- Continuous support
+- For substantial transformation
+
+**Shadow Intensive (Saturday):** €400
+
+- Full day (10am-5pm)
+- Multiple modalities
+- Small group (max 6)
+- Quarterly in Amsterdam
+
+[Explore Your Shadow →](/oracle/)

--- a/offerings/spirit-guide-connection/index.md
+++ b/offerings/spirit-guide-connection/index.md
@@ -1,0 +1,70 @@
+---
+layout: offering
+title: Spirit Guide Connection
+description: Learn to perceive and communicate with non-physical guidance. A grounded approach to spirit work for skeptics and seekers alike.
+keywords: spirit guide meditation, connect with spirit guides, spirit guide course, spiritual guidance
+permalink: /offerings/spirit-guide-connection/
+schema:
+  area: Online
+  price: 95
+  currency: EUR
+---
+
+Whether you call them guides, allies, the unconscious, or something else entirely—there are sources of intelligence and support available beyond ordinary awareness. Learning to perceive and communicate with them is a skill, not a gift reserved for special people.
+
+## The Approach
+
+This work is not about belief. It's about *perception*.
+
+We begin with techniques that produce consistent, verifiable results—internal experiences that repeat reliably and provide actionable guidance. Whether you interpret these as literal non-physical beings, personified aspects of your own unconscious, or something else, the methodology works.
+
+### Phase 1: Opening Perception
+
+- Expanding sensory awareness
+- Distinguishing imagination from reception
+- The "just making it up" problem
+- Developing your personal symbolic language
+
+### Phase 2: Making Contact
+
+- Structured journeying techniques
+- Meeting and verifying guides
+- Asking clear questions
+- Understanding the answers you receive
+
+### Phase 3: Integration
+
+- Daily practice protocols
+- When to consult guidance (and when not to)
+- Ethics of spirit work
+- Building long-term relationship
+
+## Format
+
+**Introductory Workshop:** €95
+
+- 3-hour online session
+- Guided journey experience
+- Q&A and discussion
+- Runs monthly
+
+**6-Week Course:** €445
+
+- Weekly 90-minute sessions
+- Progressive skill building
+- Small group (max 8)
+- Private online community
+
+**Private Sessions:** €750/session
+
+- Deep individual work
+- Custom journeys
+- Ongoing mentorship available
+
+## A Note on Skepticism
+
+You don't have to believe in spirit guides to benefit from this work. The techniques function regardless of your metaphysical framework. Many participants begin as skeptics and remain skeptics—they simply discover that the practice produces useful results they can't easily explain.
+
+I'm not interested in converting anyone to a belief system. I'm interested in teaching skills that work.
+
+[Ask a Question →](/oracle/)

--- a/offerings/vision-quest-facilitation/index.md
+++ b/offerings/vision-quest-facilitation/index.md
@@ -1,0 +1,74 @@
+---
+layout: offering
+title: Vision Quest Facilitation
+description: Guided wilderness rites of passage in Europe. Four days alone in nature to find clarity, purpose, and transformation.
+keywords: vision quest, wilderness rites of passage, vision quest europe, vision quest guide
+permalink: /offerings/vision-quest-facilitation/
+schema:
+  area: Europe
+  price: 1800
+  currency: EUR
+---
+
+A vision quest is not a retreat. It is a threshold—a deliberate encounter with solitude, hunger, and the raw presence of nature designed to strip away everything that is not essential.
+
+## What This Is
+
+Four days and nights alone in wilderness. No food. No shelter beyond what you carry. No distractions. Only you, the land, and whatever arises.
+
+I guide small groups (4-8 people) through the full arc:
+
+### Preparation (2 days)
+
+- Clarifying your intention
+- Learning to read signs and synchronicities
+- Understanding the ceremonial container
+- Practical wilderness skills
+
+### Threshold (4 days/nights)
+
+- Solo time in a marked sacred space
+- Daily check-ins for safety
+- Fasting with water
+
+### Integration (2 days)
+
+- Returning from the mountain
+- Storytelling and witnessing
+- Grounding the vision in daily life
+
+## Where
+
+Locations rotate seasonally across Europe:
+
+- **Ardennes (Belgium)** - Spring
+- **Scottish Highlands** - Summer
+- **Pyrenees (Spain)** - Autumn
+
+## Who This Is For
+
+You're at a threshold. Career change. Relationship ending. Midlife questioning. Creative block. Something needs to die so something new can be born.
+
+You don't need wilderness experience. You need the willingness to be uncomfortable.
+
+## Investment
+
+**Full 8-day program:** €1,800 - €2,400
+
+- Varies by location and group size
+- Includes all meals during preparation and integration
+- Does not include travel to base camp
+
+**1:1 Vision Quest Intensive:** €4,500
+
+- Private facilitation
+- Custom location
+- Extended integration support
+
+## About the Guide
+
+I've trained in wilderness rites of passage and hold deep respect for this ancient practice. My background bridges technology and contemplative practice—8 years as an engineering leader, alongside ongoing study of insight meditation, shadow work, and esoteric consultation.
+
+This combination matters. Many seekers carry questions about meaning and purpose shaped by careers in tech, finance, or other high-pressure fields. I speak both languages.
+
+[Contact to discuss →](/oracle/)

--- a/oracle/index.md
+++ b/oracle/index.md
@@ -1,0 +1,76 @@
+---
+layout: page
+title: Oracle
+description: Begin here. A brief intake to understand what you're seeking and how I might help.
+permalink: /oracle/
+---
+
+The Oracle is where we begin.
+
+Before sessions, before offerings, before anything formal—a conversation to understand what brings you here and what might serve.
+
+## How It Works
+
+1. **You share what's present** - The situation, the question, the threshold you're facing. A few sentences or a few paragraphs.
+
+2. **I respond** - Within 48 hours, I'll share initial thoughts on what might be helpful. Sometimes that's one of my offerings. Sometimes it's a resource, a practice, or a referral to someone better suited.
+
+3. **We decide together** - If there's a fit, we discuss next steps. If not, you've lost nothing but a few minutes.
+
+No commitment. No sales pitch. Just clarity.
+
+---
+
+## Ask Your Question
+
+<form action="https://formspree.io/f/YOUR_FORM_ID" method="POST" class="oracle-form">
+  <div class="form-group">
+    <label for="name">Your Name</label>
+    <input type="text" id="name" name="name" required>
+  </div>
+
+  <div class="form-group">
+    <label for="email">Email Address</label>
+    <input type="email" id="email" name="email" required>
+  </div>
+
+  <div class="form-group">
+    <label for="context">What brings you here?</label>
+    <textarea id="context" name="context" rows="4" placeholder="Brief context about your situation..."></textarea>
+  </div>
+
+  <div class="form-group">
+    <label for="question">Your question or what you're seeking</label>
+    <textarea id="question" name="question" rows="6" required placeholder="What would you like to explore? What transformation are you seeking?"></textarea>
+  </div>
+
+  <div class="form-group">
+    <label for="offerings">Any specific offerings you're curious about?</label>
+    <select id="offerings" name="offerings">
+      <option value="">Not sure yet</option>
+      <option value="vision-quest">Vision Quest Facilitation</option>
+      <option value="lucid-dreaming">Lucid Dream Training</option>
+      <option value="spirit-guides">Spirit Guide Connection</option>
+      <option value="shadow-work">Shadow Work Integration</option>
+      <option value="insight-meditation">Insight Meditation</option>
+      <option value="creative-coding">Creative Coding as Ritual</option>
+    </select>
+  </div>
+
+  <button type="submit" class="submit-button">Submit to the Oracle</button>
+</form>
+
+---
+
+## What This Isn't
+
+The Oracle isn't:
+- An AI chatbot
+- A cold email funnel
+- A barrier to accessing my work
+
+It's a human-to-human conversation, initiated with intention on both sides.
+
+## Response Time
+
+I typically respond within 48 hours. If something is urgent, say so.

--- a/oracle/index.md
+++ b/oracle/index.md
@@ -23,7 +23,10 @@ No commitment. No sales pitch. Just clarity.
 
 ## Ask Your Question
 
-<form action="https://formspree.io/f/YOUR_FORM_ID" method="POST" class="oracle-form">
+<form action="https://formsubmit.co/creativecodingtech@proton.me" method="POST" class="oracle-form">
+  <input type="hidden" name="_subject" value="New Oracle Inquiry">
+  <input type="hidden" name="_captcha" value="false">
+  <input type="hidden" name="_next" value="https://creativecodingtech.com/oracle/?submitted=true">
   <div class="form-group">
     <label for="name">Your Name</label>
     <input type="text" id="name" name="name" required>

--- a/practice/index.md
+++ b/practice/index.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: Practice
+description: Overview of all offerings - vision quests, lucid dream training, spirit guide work, shadow integration, insight meditation, and creative coding as ritual.
+permalink: /practice/
+---
+
+My work bridges the technical and the contemplative. Eight years leading engineering teams taught me how systems work. Fifteen years of contemplative practice taught me how consciousness works. The intersection is where I live.
+
+## Offerings
+
+### Wilderness & Threshold
+
+**[Vision Quest Facilitation](/offerings/vision-quest-facilitation/)**
+
+Four days and nights alone in European wilderness. The oldest technology for transformation we have. Guided preparation, safe threshold crossing, and grounded integration.
+
+### Dream & Inner Life
+
+**[Lucid Dream Training](/offerings/lucid-dream-training/)**
+
+Learn to wake up inside your dreams. A structured approach combining Western techniques with contemplative practice. Self-paced courses, live cohorts, and private training.
+
+**[Spirit Guide Connection](/offerings/spirit-guide-connection/)**
+
+Perceive and communicate with non-physical guidance. A grounded methodology that works regardless of your metaphysical framework.
+
+### Shadow & Integration
+
+**[Shadow Work Integration](/offerings/shadow-work-integration/)**
+
+Reclaim what you've rejected, hidden, or never had permission to be. Individual sessions, series work, and intensive group formats in Amsterdam.
+
+### Meditation & Contemplation
+
+**[Insight Meditation](/offerings/insight-meditation/)**
+
+Traditional vipassana practice for seeing clearly. Weekly sits in Amsterdam, individual instruction, and retreat support.
+
+### Technology & Ritual
+
+**[Creative Coding as Contemplative Practice](/offerings/creative-coding-ritual/)**
+
+Code as meditation. Algorithms as ritual. Build personal tools for transformation using TouchDesigner, Sonic Pi, and custom systems.
+
+---
+
+## How I Work
+
+I meet you where you are. Some people come with a clear question. Some come with a vague sense that something needs to change. Both are valid starting points.
+
+The [Oracle](/oracle/) is the best way to begin—a brief conversation that helps us both understand what might serve you.
+
+## Background
+
+I spent eight years as an engineering leader at companies building real-time systems. The skills I developed there—debugging complex problems, building reliable architecture, navigating uncertainty—turned out to be directly applicable to inner work.
+
+My contemplative training includes 15+ years of insight meditation, extended work with shadow integration and active imagination, training in wilderness rites of passage, and ongoing study of esoteric traditions.
+
+I hold sessions in Amsterdam and online. Vision quests happen at various locations across Europe.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://creativecodingtech.com/sitemap.xml

--- a/work/index.md
+++ b/work/index.md
@@ -1,0 +1,72 @@
+---
+layout: page
+title: Work
+description: Projects, installations, performances, and experiments at the intersection of technology and consciousness.
+permalink: /work/
+---
+
+Selected projects from the intersection of creative technology and contemplative practice.
+
+---
+
+## Installations
+
+### Breath Mirror
+
+An interactive installation that visualizes the breath of participants in real-time. Built with TouchDesigner, biofeedback sensors, and projection mapping. Exhibited at various consciousness and technology events.
+
+The piece explores how making the invisible visible changes our relationship to it. When you can see your breath as flowing light, something shifts in how you breathe.
+
+### Algorithmic Meditation
+
+A generative audio-visual environment that responds to group meditation. EEG and heart rate variability data from multiple participants shapes an evolving soundscape and visual field. The system doesn't gamify meditation—it creates a shared contemplative space.
+
+---
+
+## Performances
+
+### Live Coded Rituals
+
+Performances combining live coding (Sonic Pi, TidalCycles) with spoken word and ritual structure. Each performance is unique, written in the moment, responding to the space and audience.
+
+Recent performances include TOPLAP events, algorave gatherings, and private ceremonial contexts.
+
+### Sound Journeys
+
+Extended sonic experiences (2-4 hours) designed to support deep states. A combination of live synthesis, prepared materials, and responsive improvisation. Often paired with breathwork, meditation, or other contemplative practices.
+
+---
+
+## Workshops Developed
+
+### Conscious Coder
+
+An 8-week program exploring code as contemplative practice. Participants build personal ritual tools while developing their relationship to attention, emergence, and creative surrender.
+
+### Algorithms as Code
+
+Introduction to algorithmic thinking for artists and non-programmers. Focuses on the conceptual foundations rather than syntax, using visual and musical systems.
+
+### The Dreaming Machine
+
+A weekend intensive on working with dreams and technology. Combines lucid dream training, dream journaling practice, and building simple dream-responsive systems.
+
+---
+
+## Writing
+
+Selected articles on creative coding, consciousness, and the intersection:
+
+- [Live Coding as Contemplative Practice](/blog/)
+- [Machine Learning and Musical Intuition](/blog/)
+- [Building Tools for Transformation](/blog/)
+
+Visit the [blog](/blog/) for the full archive.
+
+---
+
+## Collaborate
+
+Interested in commissioning work, hosting a workshop, or exploring a collaboration?
+
+[Reach out through the Oracle →](/oracle/)


### PR DESCRIPTION
- Create new landing page with offerings navigation
- Add 6 offering pages: vision quest, lucid dreaming, spirit guide,
  shadow work, insight meditation, and creative coding
- Create practice overview, oracle intake form, and work/portfolio pages
- Add offering and landing layouts
- Add SCSS styles for landing page and offering pages
- Update _config.yml with new title, tagline, and SEO settings
- Add robots.txt for search engine crawling

https://claude.ai/code/session_01JQYxYXf1ZBj7ixvPJaG14U